### PR TITLE
Java 11 + jakarta support, removed javax dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ API clean-up **(still subject of change!)**. There is a SansOrm 3.7 compatibilit
 
 Numerous tests added to stabilize further development.
 
+Requires **Java 11**
+
 ### Initialization
 
 First of all we need a datasource. Once you get it, call one of ```q2o.initializeXXX``` methods:
@@ -42,7 +44,7 @@ q2o.initializeTxCustom(ds, tm, ut);
 // Starting with V 3.12 you can make q2o Spring transaction aware
 q2o.initializeWithSpringTxSupport(ds);
 
-// From V 3.13 on you can enable MySQL support. Configure MySQL with generateSimpleParameterMetadata=true, call 
+// From V 3.13 on you can enable MySQL support. Configure MySQL with generateSimpleParameterMetadata=true, call
 // one of the q2o.initialize* methods and activate MySQL mode:
 q2o.setMySqlMode(true);
 ```
@@ -188,9 +190,9 @@ or <a href=http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.h-thuro
 
 [license]:LICENSE
 [license img]:https://img.shields.io/badge/license-Apache%202-blue.svg
-   
+
 [Maven Central]:https://maven-badges.herokuapp.com/maven-central/com.github.h-thurow/q2o
 [Maven Central img]:https://maven-badges.herokuapp.com/maven-central/com.github.h-thurow/q2o/badge.svg
-   
+
 [Javadocs]:http://javadoc.io/doc/com.github.h-thurow/q2o
 [Javadocs img]:http://javadoc.io/badge/com.github.h-thurow/q2o.svg

--- a/pom.xml
+++ b/pom.xml
@@ -37,20 +37,23 @@
          <name>Holger Thurow</name>
          <email>thurow.h@gmail.com</email>
       </developer>
+      <developer>
+         <name>Paul Hafner</name>
+         <email>paulhafner1999@gmail.com</email>
+      </developer>
    </developers>
 
    <dependencies>
       <dependency>
-         <groupId>org.eclipse.persistence</groupId>
-         <artifactId>javax.persistence</artifactId>
-         <version>2.1.0</version>
-         <scope>provided</scope>
+         <groupId>jakarta.persistence</groupId>
+         <artifactId>jakarta.persistence-api</artifactId>
+         <version>3.1.0</version>
       </dependency>
       <dependency>
-         <groupId>javax.transaction</groupId>
-         <artifactId>transaction-api</artifactId>
-         <version>1.1</version>
-         <scope>provided</scope>
+         <groupId>jakarta.transaction</groupId>
+         <artifactId>jakarta.transaction-api</artifactId>
+         <version>2.0.1</version>
+         <scope>compile</scope>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
@@ -70,13 +73,6 @@
                <artifactId>junit</artifactId>
             </exclusion>
          </exclusions>
-      </dependency>
-      <dependency>
-         <groupId>javax.transaction</groupId>
-         <artifactId>javax.transaction-api</artifactId>
-         <version>1.2</version>
-         <scope>compile</scope>
-         <optional>true</optional>
       </dependency>
       <dependency>
          <groupId>junit</groupId>

--- a/src/main/java/com/zaxxer/q2o/AttributeInfo.java
+++ b/src/main/java/com/zaxxer/q2o/AttributeInfo.java
@@ -3,7 +3,7 @@ package com.zaxxer.q2o;
 import com.zaxxer.q2o.converters.*;
 import org.jetbrains.annotations.NotNull;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;

--- a/src/main/java/com/zaxxer/q2o/DatabaseValueToFieldType.java
+++ b/src/main/java/com/zaxxer/q2o/DatabaseValueToFieldType.java
@@ -7,7 +7,7 @@ import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;

--- a/src/main/java/com/zaxxer/q2o/FieldInfo.java
+++ b/src/main/java/com/zaxxer/q2o/FieldInfo.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 

--- a/src/main/java/com/zaxxer/q2o/FieldValueToDatabaseType.java
+++ b/src/main/java/com/zaxxer/q2o/FieldValueToDatabaseType.java
@@ -3,8 +3,8 @@ package com.zaxxer.q2o;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.EnumType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.EnumType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;

--- a/src/main/java/com/zaxxer/q2o/PropertyInfo.java
+++ b/src/main/java/com/zaxxer/q2o/PropertyInfo.java
@@ -1,7 +1,8 @@
 package com.zaxxer.q2o;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.beans.IntrospectionException;
+import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -24,9 +25,18 @@ class PropertyInfo extends AttributeInfo {
 
    protected void extractFieldName(final Field field) {
       try {
-         propertyDescriptor = new PropertyDescriptor(field.getName(), getOwnerClazz());
-         readMethod = propertyDescriptor.getReadMethod();
-         name = propertyDescriptor.getName();
+         Class<?> ownerClass = getOwnerClazz();
+         PropertyDescriptor[] propertyDescriptors = Introspector.getBeanInfo(ownerClass).getPropertyDescriptors();
+
+         for (PropertyDescriptor pd : propertyDescriptors) {
+            if (pd.getName().equals(field.getName())) {
+               propertyDescriptor = pd;
+               readMethod = pd.getReadMethod();
+               name = pd.getName();
+
+               break;
+            }
+         }
       }
       catch (IntrospectionException ignored) {
          // In case of fields with no getters/setters according to JavaBean conventions.

--- a/src/main/java/com/zaxxer/q2o/TransactionHelper.java
+++ b/src/main/java/com/zaxxer/q2o/TransactionHelper.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import javax.transaction.*;
+import jakarta.transaction.*;
 
 public final class TransactionHelper
 {

--- a/src/main/java/com/zaxxer/q2o/converters/CalendarDateConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/CalendarDateConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.Calendar;
 import java.util.Date;
 

--- a/src/main/java/com/zaxxer/q2o/converters/CalendarTimestampConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/CalendarTimestampConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Timestamp;
 import java.util.Calendar;
 

--- a/src/main/java/com/zaxxer/q2o/converters/CalenderTimeConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/CalenderTimeConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Time;
 import java.util.Calendar;
 

--- a/src/main/java/com/zaxxer/q2o/converters/DateTimestampConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/DateTimestampConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Timestamp;
 import java.util.Date;
 

--- a/src/main/java/com/zaxxer/q2o/converters/UtilDateDateConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/UtilDateDateConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.util.Date;
 
 /**

--- a/src/main/java/com/zaxxer/q2o/converters/UtilDateTimeConverter.java
+++ b/src/main/java/com/zaxxer/q2o/converters/UtilDateTimeConverter.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.converters;
 
-import javax.persistence.AttributeConverter;
-import javax.persistence.Converter;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 import java.sql.Time;
 import java.util.Date;
 

--- a/src/main/java/com/zaxxer/q2o/q2o.java
+++ b/src/main/java/com/zaxxer/q2o/q2o.java
@@ -3,8 +3,8 @@ package com.zaxxer.q2o;
 import com.zaxxer.q2o.transaction.TxTransactionManager;
 
 import javax.sql.DataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.UserTransaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.UserTransaction;
 
 /** Single point of q2o configuration */
 public final class q2o {

--- a/src/main/java/com/zaxxer/q2o/transaction/TxDataSource.java
+++ b/src/main/java/com/zaxxer/q2o/transaction/TxDataSource.java
@@ -17,7 +17,7 @@
 package com.zaxxer.q2o.transaction;
 
 import javax.sql.DataSource;
-import javax.transaction.Status;
+import jakarta.transaction.Status;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;

--- a/src/main/java/com/zaxxer/q2o/transaction/TxTransaction.java
+++ b/src/main/java/com/zaxxer/q2o/transaction/TxTransaction.java
@@ -16,7 +16,7 @@
 
 package com.zaxxer.q2o.transaction;
 
-import javax.transaction.*;
+import jakarta.transaction.*;
 import javax.transaction.xa.XAResource;
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/main/java/com/zaxxer/q2o/transaction/TxTransactionManager.java
+++ b/src/main/java/com/zaxxer/q2o/transaction/TxTransactionManager.java
@@ -17,7 +17,7 @@
 package com.zaxxer.q2o.transaction;
 
 import javax.sql.DataSource;
-import javax.transaction.*;
+import jakarta.transaction.*;
 import java.sql.Connection;
 import java.sql.SQLException;
 

--- a/src/main/java/com/zaxxer/sansorm/SansOrm.java
+++ b/src/main/java/com/zaxxer/sansorm/SansOrm.java
@@ -3,8 +3,8 @@ package com.zaxxer.sansorm;
 import com.zaxxer.q2o.q2o;
 
 import javax.sql.DataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.UserTransaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.UserTransaction;
 
 /** Single point of SansOrm configuration
  * @deprecated

--- a/src/test/java/com/zaxxer/q2o/AccessTypePropertyTest.java
+++ b/src/test/java/com/zaxxer/q2o/AccessTypePropertyTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sansorm.testutils.*;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.lang.reflect.InvocationTargetException;

--- a/src/test/java/com/zaxxer/q2o/AutoCommitTest.java
+++ b/src/test/java/com/zaxxer/q2o/AutoCommitTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sansorm.DataSources;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/com/zaxxer/q2o/CaseSensitiveDatabasesLiveTest.java
+++ b/src/test/java/com/zaxxer/q2o/CaseSensitiveDatabasesLiveTest.java
@@ -8,10 +8,10 @@ import org.junit.Test;
 import org.sansorm.DataSources;
 import org.sansorm.testutils.GeneralTestConfigurator;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/zaxxer/q2o/CaseSensitiveDatabasesTest.java
+++ b/src/test/java/com/zaxxer/q2o/CaseSensitiveDatabasesTest.java
@@ -6,10 +6,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sansorm.testutils.*;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.*;
 import java.util.HashSet;
 

--- a/src/test/java/com/zaxxer/q2o/CompositeKeyTest.java
+++ b/src/test/java/com/zaxxer/q2o/CompositeKeyTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sansorm.testutils.GeneralTestConfigurator;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.Connection;
 import java.sql.SQLException;
 

--- a/src/test/java/com/zaxxer/q2o/FieldColumnInfoTest.java
+++ b/src/test/java/com/zaxxer/q2o/FieldColumnInfoTest.java
@@ -2,10 +2,10 @@ package com.zaxxer.q2o;
 
 import org.junit.Test;
 
-import javax.persistence.Column;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/zaxxer/q2o/IntrospectedTest.java
+++ b/src/test/java/com/zaxxer/q2o/IntrospectedTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.sansorm.TargetClass1;
 import org.sansorm.sqlite.TargetClassSQL;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.lang.reflect.Field;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/com/zaxxer/q2o/LobSpringTxTest.java
+++ b/src/test/java/com/zaxxer/q2o/LobSpringTxTest.java
@@ -12,7 +12,7 @@ import org.sansorm.testutils.TxMode;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/zaxxer/q2o/LobTest.java
+++ b/src/test/java/com/zaxxer/q2o/LobTest.java
@@ -13,7 +13,7 @@ import org.sansorm.DataSources;
 import org.sansorm.testutils.Database;
 import org.sansorm.testutils.TxMode;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/com/zaxxer/q2o/OneToManyTest.java
+++ b/src/test/java/com/zaxxer/q2o/OneToManyTest.java
@@ -7,10 +7,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.sansorm.DataSources;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToMany;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/src/test/java/com/zaxxer/q2o/OrmBaseTest.java
+++ b/src/test/java/com/zaxxer/q2o/OrmBaseTest.java
@@ -5,7 +5,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.sansorm.DataSources;
 
-import javax.persistence.Id;
+import jakarta.persistence.Id;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/com/zaxxer/q2o/PropertyInfoTest.java
+++ b/src/test/java/com/zaxxer/q2o/PropertyInfoTest.java
@@ -6,10 +6,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 

--- a/src/test/java/com/zaxxer/q2o/Q2ObjListTest.java
+++ b/src/test/java/com/zaxxer/q2o/Q2ObjListTest.java
@@ -5,8 +5,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.sansorm.testutils.GeneralTestConfigurator;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/com/zaxxer/q2o/Q2ObjTest.java
+++ b/src/test/java/com/zaxxer/q2o/Q2ObjTest.java
@@ -10,10 +10,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sansorm.testutils.*;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.*;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/com/zaxxer/q2o/RefreshTest.java
+++ b/src/test/java/com/zaxxer/q2o/RefreshTest.java
@@ -9,10 +9,10 @@ import org.junit.Test;
 import org.sansorm.DataSources;
 import org.sansorm.testutils.*;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.*;
 
 import static com.zaxxer.q2o.Q2Obj.insert;

--- a/src/test/java/com/zaxxer/q2o/SelfJoinManyToOneFieldAccessTest.java
+++ b/src/test/java/com/zaxxer/q2o/SelfJoinManyToOneFieldAccessTest.java
@@ -4,7 +4,7 @@ import org.h2.jdbcx.JdbcDataSource;
 import org.junit.Test;
 import org.sansorm.DataSources;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/src/test/java/com/zaxxer/q2o/TransactionsTest.java
+++ b/src/test/java/com/zaxxer/q2o/TransactionsTest.java
@@ -7,9 +7,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.sansorm.DataSources;
 
-import javax.persistence.Entity;
+import jakarta.persistence.Entity;
 import javax.sql.DataSource;
-import javax.transaction.Transaction;
+import jakarta.transaction.Transaction;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/com/zaxxer/q2o/entities/CaseSensitiveDatabasesClass.java
+++ b/src/test/java/com/zaxxer/q2o/entities/CaseSensitiveDatabasesClass.java
@@ -1,8 +1,8 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Column;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/CompositeKey.java
+++ b/src/test/java/com/zaxxer/q2o/entities/CompositeKey.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Id;
+import jakarta.persistence.Id;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/DataTypes.java
+++ b/src/test/java/com/zaxxer/q2o/entities/DataTypes.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigInteger;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/src/test/java/com/zaxxer/q2o/entities/DataTypesNullable.java
+++ b/src/test/java/com/zaxxer/q2o/entities/DataTypesNullable.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigInteger;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/src/test/java/com/zaxxer/q2o/entities/DelimitedFields.java
+++ b/src/test/java/com/zaxxer/q2o/entities/DelimitedFields.java
@@ -1,8 +1,8 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Table;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)
@@ -10,7 +10,7 @@ import javax.persistence.Table;
  */
 @Table(name = "\"Test Class\"")
 public class DelimitedFields {
-   @javax.persistence.Id
+   @jakarta.persistence.Id
    @GeneratedValue
    public
    int Id;

--- a/src/test/java/com/zaxxer/q2o/entities/FarRight1.java
+++ b/src/test/java/com/zaxxer/q2o/entities/FarRight1.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/GetterAnnotatedPitMainEntity.java
+++ b/src/test/java/com/zaxxer/q2o/entities/GetterAnnotatedPitMainEntity.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.sql.Timestamp;
 import java.util.Collection;
 

--- a/src/test/java/com/zaxxer/q2o/entities/GetterAnnotatedPitReferenceEntity.java
+++ b/src/test/java/com/zaxxer/q2o/entities/GetterAnnotatedPitReferenceEntity.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Collection;
 
 /**

--- a/src/test/java/com/zaxxer/q2o/entities/Left.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Left.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/Left1.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Left1.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/Left2.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Left2.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/LeftOneToMany.java
+++ b/src/test/java/com/zaxxer/q2o/entities/LeftOneToMany.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Collection;
 
 /**

--- a/src/test/java/com/zaxxer/q2o/entities/Middle1.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Middle1.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/OrderSummary.java
+++ b/src/test/java/com/zaxxer/q2o/entities/OrderSummary.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Column;
+import jakarta.persistence.Column;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/PropertyAccessedOneToOneSelfJoin.java
+++ b/src/test/java/com/zaxxer/q2o/entities/PropertyAccessedOneToOneSelfJoin.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/PropertyAccessedSelfJoin.java
+++ b/src/test/java/com/zaxxer/q2o/entities/PropertyAccessedSelfJoin.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/PropertyDescriptorTestClass.java
+++ b/src/test/java/com/zaxxer/q2o/entities/PropertyDescriptorTestClass.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Column;
+import jakarta.persistence.Column;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/Right.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Right.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/Right1.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Right1.java
@@ -1,6 +1,6 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/com/zaxxer/q2o/entities/Right2.java
+++ b/src/test/java/com/zaxxer/q2o/entities/Right2.java
@@ -1,7 +1,7 @@
 package com.zaxxer.q2o.entities;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/opix/domain/filetypes/filetypes/FileTypeEntity.java
+++ b/src/test/java/opix/domain/filetypes/filetypes/FileTypeEntity.java
@@ -1,6 +1,6 @@
 package opix.domain.filetypes.filetypes;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Collection;
 
 /**

--- a/src/test/java/opix/domain/filetypes/filetypes/WinExtensionEntity.java
+++ b/src/test/java/opix/domain/filetypes/filetypes/WinExtensionEntity.java
@@ -1,6 +1,6 @@
 package opix.domain.filetypes.filetypes;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * @author Holger Thurow (thurow.h@gmail.com)

--- a/src/test/java/org/sansorm/BaseClass.java
+++ b/src/test/java/org/sansorm/BaseClass.java
@@ -1,9 +1,9 @@
 package org.sansorm;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 
 @MappedSuperclass
 public class BaseClass

--- a/src/test/java/org/sansorm/DateConverter.java
+++ b/src/test/java/org/sansorm/DateConverter.java
@@ -3,7 +3,7 @@ package org.sansorm;
 import java.time.Instant;
 import java.util.Date;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 public class DateConverter implements AttributeConverter<Date, Number> {
    @Override

--- a/src/test/java/org/sansorm/MySQLEnumTests.java
+++ b/src/test/java/org/sansorm/MySQLEnumTests.java
@@ -8,7 +8,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.sql.SQLException;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/sansorm/TargetClass1.java
+++ b/src/test/java/org/sansorm/TargetClass1.java
@@ -1,8 +1,8 @@
 package org.sansorm;
 
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Table;
 import java.util.Date;
 
 @Table(name = "target_class1")

--- a/src/test/java/org/sansorm/TargetClass2.java
+++ b/src/test/java/org/sansorm/TargetClass2.java
@@ -1,8 +1,8 @@
 package org.sansorm;
 
-import javax.persistence.Entity;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 
 @Entity

--- a/src/test/java/org/sansorm/TargetTimestampClass1.java
+++ b/src/test/java/org/sansorm/TargetTimestampClass1.java
@@ -1,9 +1,9 @@
 package org.sansorm;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.Timestamp;
 
 /**

--- a/src/test/java/org/sansorm/TestConverter.java
+++ b/src/test/java/org/sansorm/TestConverter.java
@@ -1,6 +1,6 @@
 package org.sansorm;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 public class TestConverter implements AttributeConverter<String, Number> {
 

--- a/src/test/java/org/sansorm/sqlite/TargetClassSQL.java
+++ b/src/test/java/org/sansorm/sqlite/TargetClassSQL.java
@@ -4,11 +4,11 @@ import org.sansorm.DateConverter;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.Convert;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Table
 public class TargetClassSQL

--- a/src/test/java/playground/AnnotationsCheckTest.java
+++ b/src/test/java/playground/AnnotationsCheckTest.java
@@ -15,10 +15,10 @@ import org.sansorm.DataSources;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Persistence;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
 import javax.sql.DataSource;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -15,10 +15,10 @@
       <properties>
 
 <!--  Reuse JNDI bound datasource instead. See non-jta-data-source above. -->
-<!--         <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/q2o" />-->
-<!--         <property name="javax.persistence.jdbc.user" value="root" />-->
-<!--         <property name="javax.persistence.jdbc.password" value="yxcvbnm" />-->
-<!--         <property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver" />-->
+<!--         <property name="jakarta.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/q2o" />-->
+<!--         <property name="jakarta.persistence.jdbc.user" value="root" />-->
+<!--         <property name="jakarta.persistence.jdbc.password" value="yxcvbnm" />-->
+<!--         <property name="jakarta.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver" />-->
 
          <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect"/>
          <!-- DB schema will be updated if needed -->


### PR DESCRIPTION
Moving from javax.{validation|transaction}.* APIs to jakarta.{validation|transaction}.* APIs